### PR TITLE
Prefer vjs.registerPlugin over vjs.plugin

### DIFF
--- a/videojs.persistvolume.js
+++ b/videojs.persistvolume.js
@@ -120,6 +120,6 @@
     });
   };
 
-  vjs.plugin("persistvolume", volumePersister);
+  vjs[ (vjs.registerPlugin ? 'registerPlugin' : 'plugin') ]("persistvolume", volumePersister);
 
 });


### PR DESCRIPTION
With the current version of video.js this code produces a warning using the deprecated plugin loading method.

This patch will support both methods.